### PR TITLE
[IMP] make picking state syncing configurable

### DIFF
--- a/purchase_sale_inter_company/models/res_company.py
+++ b/purchase_sale_inter_company/models/res_company.py
@@ -47,6 +47,13 @@ class ResCompany(models.Model):
         default="raise",
         help="Pick action to perform on sync picking failure",
     )
+    sync_picking_state = fields.Boolean(
+        string="Sync the receipt state with the delivery state",
+        default=lambda p: p.sync_picking,
+        help="State of receipt picking syncs with state of the delivery "
+        "from the source company. Note this disallows user to manually "
+        "correct or change a picking that did not sync properly.",
+    )
     block_po_manual_picking_validation = fields.Boolean(
         string="Block manual validation of picking in the destination company",
     )

--- a/purchase_sale_inter_company/models/res_config.py
+++ b/purchase_sale_inter_company/models/res_config.py
@@ -49,6 +49,9 @@ class InterCompanyRulesConfig(models.TransientModel):
     )
     sync_picking_failure_action = fields.Selection(
         related="company_id.sync_picking_failure_action",
+    )
+    sync_picking_state = fields.Boolean(
+        related="company_id.sync_picking_state",
         readonly=False,
     )
     block_po_manual_picking_validation = fields.Boolean(

--- a/purchase_sale_inter_company/models/stock_picking.py
+++ b/purchase_sale_inter_company/models/stock_picking.py
@@ -21,7 +21,8 @@ class StockPicking(models.Model):
         res = super()._compute_state()
         for picking in self:
             if (
-                picking.intercompany_picking_id
+                picking.company_id.sync_picking_state
+                and picking.intercompany_picking_id
                 and picking.picking_type_code == "incoming"
                 and picking.state not in ["done", "cancel"]
             ):

--- a/purchase_sale_inter_company/views/res_config_view.xml
+++ b/purchase_sale_inter_company/views/res_config_view.xml
@@ -63,6 +63,13 @@
                         class="oe_inline"
                     />
                     <br />
+                    <field name="sync_picking_state" class="oe_inline" />
+                    <label
+                        string="Sync picking state"
+                        class="o_light_label"
+                        for="sync_picking_state"
+                    />
+                    <br />
                     <field
                         name="block_po_manual_picking_validation"
                         class="oe_inline"


### PR DESCRIPTION
By default picking state is forced to Done when SO picking is done, but if picking sync fails, eg if there is a mismatch in SO and PO move lines, user can't correct anything since the picking is already set to Done.

This may be acceptable in cases where 100% of the syncs go OK but we make the setting configurable to support situations where manual corrections are needed.